### PR TITLE
Add cryptography dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For the complete API reference, go to the [API reference](https://api.fireblocks
 Make sure you have the credentials for Fireblocks API Services. Otherwise, please contact Fireblocks support for further instructions on how to obtain your API credentials.
 
 ### Requirements
-Python 3.6 and later.
+Python 3.6 or newer.
 
 ### Installation
 `pip install fireblocks-sdk`

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ setup(
   keywords = ['Fireblocks', 'SDK'],
   install_requires=[
           'PyJWT==1.7.1',
+          'cryptography==2.7',
+          'pycryptodome==3.9.0',
           'requests==2.22.0',
       ],
   classifiers=[


### PR DESCRIPTION
To allow RS256 encryption in PyJWT, it is required to have additional libraries installed.
This change set adds the required libraries to the dependencies list.