### PR TITLE
Add User-Agent HTTP header

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,10 +4,11 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [macos-11, macos-12, windows-latest, ubuntu-18.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,13 +19,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Build package
+        run: pip install -e .
 #      - name: Test with pytest
 #        run: |
 #          pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,16 +4,14 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ fireblocks = FireblocksSDK(private_key, api_key)
 
 You can also pass additional arguments:
 ```python
-fireblocks = FireblocksSDK(private_key, api_key, api_base_url="https://api.fireblocks.io", timeout=2000, anonymous_platform=True)
+fireblocks = FireblocksSDK(private_key, api_key, api_base_url="https://api.fireblocks.io", timeout=2.0, anonymous_platform=True)
 ```

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ Python 3.6 or newer.
 
 ### Installation
 `pip3 install fireblocks-sdk`
+
+#### Importing Fireblocks SDK
+```python
+from fireblocks_sdk import FireblocksSDK
+
+fireblocks = FireblocksSDK(private_key, api_key)
+```
+
+You can also pass additional arguments:
+```python
+fireblocks = FireblocksSDK(private_key, api_key, api_base_url="https://api.fireblocks.io", timeout=2000, anonymous_platform=True)
+```


### PR DESCRIPTION
## Pull Request Description

Add User-Agent header to every HTTP request.

Examples:
- When `anonymousPlatform` isn't passed / `False` - `fireblocks-sdk-py/1.17.2`
- When `anonymousPlatform` is `True` - `fireblocks-sdk-py/1.17.2 (Darwin 21.6.0; CPython 3.9.6; arm64)`

Note:
The OS types is `Linux` on Linux, `Darwin` on macOS, and `Windows_NT` on Windows.

I've also added a step in the `python-package.yml` workflow to test the package installation (linting isn't enough) on multiple OSs.

## Type of change

- [x] Chore / Documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally tested against Fireblocks API

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added corresponding labels to the PR
