### PR TITLE
Remove legacy "object" clutter in class definitions

### DIFF
--- a/fireblocks_sdk/api_types.py
+++ b/fireblocks_sdk/api_types.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Optional, List, Union
 
+
 def snake_to_camel(snake_case: str):
     words = snake_case.split('_')
     return words[0] + ''.join(word.capitalize() for word in words[1:])
@@ -19,7 +20,7 @@ def convert_class_to_dict(class_dict: dict):
     return output_dict
 
 
-class TransferPeerPath(object):
+class TransferPeerPath:
     def __init__(self, peer_type, peer_id):
         """Defines a source or a destination for a transfer
 
@@ -139,7 +140,7 @@ LOW = "LOW"
 FEE_LEVEL = (HIGH, MEDIUM, LOW)
 
 
-class TransferTicketTerm(object):
+class TransferTicketTerm:
     def __init__(self, network_connection_id, outgoing, asset, amount, note=None, operation=TRANSACTION_TRANSFER):
         """Defines a transfer ticket's term
 
@@ -161,7 +162,7 @@ class TransferTicketTerm(object):
         self.operation = operation
 
 
-class UnsignedMessage(object):
+class UnsignedMessage:
     def __init__(self, content, bip44addressIndex=None, bip44change=None, derivationPath=None):
         """Defines message to be signed by raw transaction
 
@@ -184,7 +185,7 @@ class UnsignedMessage(object):
             self.derivationPath = derivationPath
 
 
-class RawMessage(object):
+class RawMessage:
     def __init__(self, messages, algorithm=None):
         """Defines raw message
 
@@ -198,7 +199,7 @@ class RawMessage(object):
             self.algorithm = algorithm
 
 
-class TransactionDestination(object):
+class TransactionDestination:
     def __init__(self, amount, destination):
         """Defines destinations for multiple outputs transaction
 
@@ -225,7 +226,7 @@ class FireblocksApiException(Exception):
         super().__init__(self.message)
 
 
-class PagedVaultAccountsRequestFilters(object):
+class PagedVaultAccountsRequestFilters:
     """ Optional filters to apply for request
 
     Args
@@ -257,7 +258,7 @@ class PagedVaultAccountsRequestFilters(object):
         self.after = after
 
 
-class PagedExchangeAccountRequestFilters(object):
+class PagedExchangeAccountRequestFilters:
     """ Optional filters to apply for request
 
     Args
@@ -277,7 +278,7 @@ class PagedExchangeAccountRequestFilters(object):
         self.after = after
 
 
-class GetAssetWalletsFilters(object):
+class GetAssetWalletsFilters:
     """ Optional filters to apply for request
 
     Args
@@ -302,7 +303,7 @@ class GetAssetWalletsFilters(object):
         self.after = after
 
 
-class GetSmartTransferFilters(object):
+class GetSmartTransferFilters:
     """ Optional filters to apply for request
     Args
         query (string, optional):  Search query string - either ticketId, asset or network name

--- a/fireblocks_sdk/sdk.py
+++ b/fireblocks_sdk/sdk.py
@@ -74,7 +74,7 @@ def handle_response(response, page_mode=False):
         return response_data
 
 
-class FireblocksSDK(object):
+class FireblocksSDK:
     def __init__(
             self,
             private_key,

--- a/fireblocks_sdk/sdk_token_provider.py
+++ b/fireblocks_sdk/sdk_token_provider.py
@@ -5,7 +5,8 @@ import math
 import secrets
 from hashlib import sha256
 
-class SdkTokenProvider(object):
+
+class SdkTokenProvider:
     def __init__(self, private_key, api_key, seconds_jwt_exp):
         self.private_key = private_key
         self.api_key = api_key


### PR DESCRIPTION
All classes in Python3 automatically inherit from object. There's no need to do it explicitly like in Python2.