### PR TITLE
fix api url for invoke_wallet_rpc

### DIFF
--- a/fireblocks_sdk/ncw_sdk.py
+++ b/fireblocks_sdk/ncw_sdk.py
@@ -154,7 +154,7 @@ class FireblocksNCW:
         """
         payload: stringified JSON, message originated in the NCW SDK
         """
-        url = f"{self._wallet_url}/{wallet_id}/devices/{device_id}/rpc"
+        url = f"{self._wallet_url}/{wallet_id}/devices/{device_id}/invoke"
         body = {"payload": payload}
 
         return self.sdk._post_request(url, body)


### PR DESCRIPTION
---
name: fix api url for invoke_wallet_rpc
about: fix unknown error when calling the invoke_wallet_rpc method (invalid endpoint)
title: fix api url for invoke_wallet_rpc
labels: bug
assignees: tomervil, yarinvak

---

**Describe the bug**
When using the invoke_wallet_rpc endpoint, the SDK returns the following error: `fireblocks_sdk.api_types.FireblocksApiException: Got an error from fireblocks server: {"errorCode":"UNKNOWN","errorMessage":"Cannot POST /v1/wallets/xxxxxxxxxxxxx/devices/xxxxxxxxxxxxx/rpc"}`

**To Reproduce**
Steps to reproduce the behavior:
1. Create a wallet
2. Create a device
3. Initialize the frontend sdk (web)
4. The frontend sdk calls the rpc endpoint on the backend sending `{"method":"get_service_certificates","headers":{"sdkVersion":"2.0.0","mpcVersion":6,"physicalDeviceId":"xxxxxxxxxxxxxxxx","platformType":"Web"}}`
5. The backend calls Fireblocks's API and obtain the error `fireblocks_sdk.api_types.FireblocksApiException: Got an error from fireblocks server: {"errorCode":"UNKNOWN","errorMessage":"Cannot POST /v1/wallets/xxxxxxxxxxxxx/devices/xxxxxxxxxxxxx/rpc"}`

**Expected behavior**
The SDK should not return an error to the backend, it should correctly initialize the SDK or return a meaningful error.

**Versions (please complete the following information):**
 - Python Version: 3.10.6
 - fireblocks-sdk version: 2.0.0

**Additional context**
Checking in the JS SDK and in the API documentation, the endpoint should be `/{wallet_id}/devices/{device_id}/invoke` instead of `/{wallet_id}/devices/{device_id}/rpc`