### PR TITLE
:bug: fix(#154): TypeError: 'type' object is not subscriptable

### DIFF
--- a/fireblocks_sdk/tokenization_api_types.py
+++ b/fireblocks_sdk/tokenization_api_types.py
@@ -157,7 +157,7 @@ class ContractUploadRequest(BaseDictClass):
             docs: Optional[object] = None,
             attributes: Optional[Dict[str, str]] = None,
             type: Optional[ContractTemplateType] = None,
-            input_fields_metadata: Optional[dict[str, FieldMetadata]] = None,
+            input_fields_metadata: Optional[Dict[str, FieldMetadata]] = None,
     ):
         self.name = name
         self.description = description


### PR DESCRIPTION
fixes #154 

I faced the same issue, and had to fix locally.
https://stackoverflow.com/questions/59101121/type-hint-for-a-dict-gives-typeerror-type-object-is-not-subscriptable