### PR TITLE
Fix broken Python 3.7+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For the complete API reference, go to the [API reference](https://developers.fir
 Make sure you have the credentials for Fireblocks API Services. Otherwise, please contact Fireblocks support for further instructions on how to obtain your API credentials.
 
 ### Requirements
-Python 3.6 or newer.
+Python 3.7 or newer.
 
 ### Installation
 `pip3 install fireblocks-sdk`

--- a/fireblocks_sdk/api_types.py
+++ b/fireblocks_sdk/api_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import Optional, List, Union
 

--- a/fireblocks_sdk/tokenization_api_types.py
+++ b/fireblocks_sdk/tokenization_api_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC
 from enum import Enum
 from typing import Optional, List, Union, Dict

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     'Intended Audience :: Developers',
     'Topic :: Software Development',
     'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
   ],
 )


### PR DESCRIPTION
Officially the SDK declares support for Python versions from 3.6 and up. However, it crashes due to typing if used by Python version below 3.10.

This fixes it for all Python versions from 3.7.
Additionally, it increases the minimum supported version of Python from 3.6 (which has reached its EOL in 2021) to 3.7.