### PR TITLE
Preserve original remote error attributes in API exception

### DIFF
--- a/fireblocks_sdk/api_types.py
+++ b/fireblocks_sdk/api_types.py
@@ -216,14 +216,28 @@ class FireblocksApiException(Exception):
     """Exception raised for Fireblocks sdk errors
 
     Attributes:
-        message: explanation of the error
+        reason: explanation of the error
+        error_message: original remote error message
         error_code: error code of the error
+        http_code: HTTP status code of the response
     """
-
-    def __init__(self, message="Fireblocks SDK error", error_code=None):
-        self.message = message
+    def __init__(self,
+                 reason: str = '',
+                 error_message: Optional[str] = None,
+                 error_code: Optional[int] = None,
+                 http_code: Optional[int] = None):
+        self.error_message = error_message
         self.error_code = error_code
-        super().__init__(self.message)
+        self.http_code = http_code
+
+        display_error = reason or \
+                        (error_message and f"Got an error from fireblocks server: {error_message}") or \
+                        "Fireblocks SDK error"
+
+        super().__init__(display_error)
+
+        # Let's maintain the .message attribute for backwards compatibility purposes
+        self.message = display_error
 
 
 class PagedVaultAccountsRequestFilters:

--- a/fireblocks_sdk/sdk.py
+++ b/fireblocks_sdk/sdk.py
@@ -50,18 +50,19 @@ from .sdk_token_provider import SdkTokenProvider
 def handle_response(response, page_mode=False):
     try:
         response_data = response.json()
-    except:
+    except (AttributeError, ValueError):
         response_data = None
-    if response.status_code >= 300:
-        if type(response_data) is dict:
-            error_code = response_data.get("code")
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        if isinstance(response_data, dict):
+            error_code = response_data.get('code')
+            message = response_data.get('message')
             raise FireblocksApiException(
-                "Got an error from fireblocks server: " + response.text, error_code
-            )
+                error_message=message, error_code=error_code, http_code=response.status_code) from err
         else:
-            raise FireblocksApiException(
-                "Got an error from fireblocks server: " + response.text
-            )
+            raise FireblocksApiException(error_message=response.text, http_code=response.status_code) from err
     else:
         if page_mode:
             return {


### PR DESCRIPTION
What this fixes:
 - wild "except" statement
 - non-Pythonic direct type comparison (even worse, with "is")
 - textual FB response message is parsed and preserved; this may be handy when trying to automatically propagate a meaningful textual error reason somewhere upstream in the code (e.g. operator dashboard panel)
 - original HTTP status code is now preserved for easier debugging under the http_code attribute
 - original requests status exception is nicely chained (with the extended raise from statement)