### PR TITLE
Update sdk.py

### DIFF
--- a/fireblocks_sdk/sdk.py
+++ b/fireblocks_sdk/sdk.py
@@ -1139,7 +1139,7 @@ class FireblocksSDK:
             external_tx_id (str): The external id of the transaction
         """
 
-        return self._get_request(f"/v1/transactions/external_tx_id/{urllib.quote(external_tx_id, safe='')}")
+        return self._get_request(f"/v1/transactions/external_tx_id/{urllib.parse.quote(external_tx_id, safe='')}")
 
     def get_fee_for_asset(self, asset_id):
         """Gets the estimated fees for an asset


### PR DESCRIPTION
Fixed urllib quote in get_transaction_by_external_id()

The urllib module has been split into parts in python 3 and renamed in to urllib.request, urllib.parse

the correct call is:
urllib.parse.quote(external_tx_id, safe='')