### PR TITLE
Pass treatAsGrossAmount if set to False in create_transaction

### DIFF
--- a/fireblocks_sdk/sdk.py
+++ b/fireblocks_sdk/sdk.py
@@ -1653,7 +1653,7 @@ class FireblocksSDK:
         if replace_tx_by_hash:
             body["replaceTxByHash"] = replace_tx_by_hash
 
-        if treat_as_gross_amount:
+        if treat_as_gross_amount is not None:
             body["treatAsGrossAmount"] = treat_as_gross_amount
 
         if destinations:


### PR DESCRIPTION
Explanation: Despite the docs currently suggesting False is the default, it is not always the case as explained by Ricky Chen, Fireblocks Platinum Support Engineer, in Fireblocks support ticket 183501.

Excerpt from the thread:

**_[Jozef Knaperek]_**
Citing the docs:
> treatAsGrossAmount
> The value is false by default. If it is set to true, the network fee is deducted from the requested amount.

Ref: https://developers.fireblocks.com/reference/create-transactions#treatasgrossamount

We do not set anything explicitly in the Python SDK when calling the `create_transaction` method, where the `treat_as_gross_amount` parameter is `None` by default. Looking at the SDK code, it is obvious that the parameter does not get sent unless it's set to True, so it wouldn't make any difference even if we set it to False explicitly when calling the `create_transaction` method.

I'm thinking, and this is where I'd like your input to confirm or correct my hypothesis, maybe the default behavior of Fireblocks is to NOT treat the transactions as gross UNLESS the whole vault account balance is about to be spent. In that special case Fireblocks defaults to treating the transaction as gross (despite the docs not mentioning this edge case). Can you please confirm if this statement is factually correct?

Now, second question is whether Fireblocks ALWAYS respects the `treatAsGrossAmount` request parameter, if provided explicitly (no matter if true or false). If so, will it respect the parameter value even if set to false while attempting to spend the whole Vault Account balance? What is the behavior in that case?

If the answer is YES for both questions, then I suggest fixing the SDK code to pass the treatAsGrossAmount parameter at all times (even if it's False). I can send a pull request fixing this as long as my hypothesis is correct.

Thank you Ricky, it's been a huge mystery but I feel we're coming closer to the resolution finally :-)

**_[Ricky Chen]_**
1. Yes, the transaction will not be treated as gross unless the whole account vault balance is spent.
2. If the treatAsGrossAmount is set in the transaction parameters, then the transaction will follow this field. If you send a transaction with the treatAsGrossAmount as false but the entire vault balance amount, then the transaction will fail with insufficient funds.